### PR TITLE
Removed use of eval, and replaced with evaluate from 'mathjs' library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 
 script:
-  # - npm test
+  - npm test
   - npm run build
   # - ls node_modules
 

--- a/src/App.js
+++ b/src/App.js
@@ -252,6 +252,7 @@ class App extends React.Component {
     }
     return result;
   };
+  }
 
   getLastChar = (from) => {
     return from.slice(-1);

--- a/src/App.js
+++ b/src/App.js
@@ -135,7 +135,7 @@ class App extends React.Component {
     if (matches.length > 1 && matches[0] === result) {
       //I need to handle the double equal
       if ("+-/*".includes(operate) && !isNaN(originalLastNum)) {
-        finalResult = (eval(result + operate + originalLastNum) | "") + "";
+        finalResult = (evaluate(result + operate + originalLastNum) | "") + "";
       }
     } else {
       /*
@@ -171,7 +171,7 @@ class App extends React.Component {
           //we extract the first expression ex:  (2+5)
           let expression = parenthesisToCalculate[i];
           //We calculate the value ex: 7
-          let tempResult = eval(expression);
+          let tempResult = evaluate(expression);
           //We need to replace the expression by the calculation
           tempResultString = tempResultString.replace(expression, tempResult);
         }
@@ -179,7 +179,7 @@ class App extends React.Component {
       }
       //In tempResultString we have the last expression withtout any ()
 
-      finalResult = eval(tempResultString);
+      finalResult = evaluate(tempResultString);
     }
 
     this.setState({

--- a/src/App.js
+++ b/src/App.js
@@ -79,11 +79,8 @@ class App extends React.Component {
     if (results.length === 0) {
       return "";
     }
-
     //We need to take the last one
     let lastNum = results[results.length - 1];
-    // console.log();
-
     // If there is no operator -> we return the value
     if (!"-+/*".includes(lastNum[0])) {
       return lastNum;
@@ -92,18 +89,6 @@ class App extends React.Component {
       operate: lastNum[0],
     });
     return lastNum.substr(1);
-
-    /*
-    // If there is one sign, we remove itr
-    const operatorsCount = (result.match(/[-+/*]/g) || []).length;
-    if (operatorsCount === 1) {
-      return lastNum.substr(1)
-    }
-    // If there are two operator (operator+sign) -> we remove the first and keep the sign
-    if (operatorsCount === 2) {
-      return lastNum.substr(1)
-    }
-*/
   };
 
   changeKeys = (result, button) => {

--- a/src/App.js
+++ b/src/App.js
@@ -231,7 +231,7 @@ class App extends React.Component {
     //return "not yet coded";
     return result;
   };
-
+  }
 
   closeParens = (result) => {
     var numberOfOpenP = (result.match(/\(/g) || []).length;

--- a/src/App.js
+++ b/src/App.js
@@ -107,7 +107,6 @@ class App extends React.Component {
   };
 
   changeKeys = (result, button) => {
-
     if ("(".includes(button)) {
       if (result.length > 1) {
         if ("0123456789".includes(result[result.length - 1])) {
@@ -124,7 +123,6 @@ class App extends React.Component {
         return "0.";
       }
     }
-
     if ("0123456789".includes(result[result.length - 1])) {
       const numberOfOpenP = (result.match(/\(/g) || []).length;
       const numberOfCloseP = (result.match(/\)/g) || []).length;
@@ -149,7 +147,6 @@ class App extends React.Component {
         return result + "0.";
       }
     }
-
     //🪲BUG -> (7 +  isn't working, attempting fix with this if conditional
     if (
       result[result.length - 1] === "(" &&
@@ -158,11 +155,9 @@ class App extends React.Component {
     ) {
       return result + button;
     }
-
     // After a ), you can only have
     // - operator
     // - ), only if there are more ( than )
-
     if (result[result.length - 1] === ")") {
       const numberOfOpenP = (result.match(/\(/g) || []).length;
       const numberOfCloseP = (result.match(/\)/g) || []).length;
@@ -173,7 +168,6 @@ class App extends React.Component {
         return result + button;
       }
     }
-
     //QS: will we run into a problem in differentiating an operator from a sign? */
     //For  + / , how do you know it's an operator, or a sign (7--)
     // You need to watch what is before
@@ -186,7 +180,6 @@ class App extends React.Component {
     // - sign
     // - (
     // - ., but we need to add a zero before
-
     if ("0123456789)".includes(result[result.length - 2])) {
       //checking "digit, ) -> operator"
       if ("/*+-".includes(result[result.length - 1])) {
@@ -198,12 +191,10 @@ class App extends React.Component {
         }
       }
     }
-
     // After a sign, you can only have
     // - digit
     // - (
     // - ., but we need to add a zero before
-
     if ("/*+-(".includes(result[result.length - 2])) {
       if ("-+".includes(result[result.length - 1])) {
         if ("0123456789(".includes(button)) {
@@ -214,12 +205,10 @@ class App extends React.Component {
         }
       }
     }
-
     // After a sign, you can only have
     // - digit
     // - (
     // - ., but we need to add a zero before
-
     if (result[result.length - 2].includes("/*+-(")) {
       if (result[result.length - 1].includes("-+")) {
         if ("0123456789(".includes(button)) {
@@ -230,18 +219,14 @@ class App extends React.Component {
         }
       }
     }
-
     if ((result[result.length - 1] || "").includes(".")) {
 
       if ("0123456789".includes(button)) {
         return result + button;
       }
     }
-
-
     //🪲 72.2 + doesn't work FIXED
     if (result.includes(".")) {
-      
     //ATTN -> added rule below myself outside of our tutoring
        //🪲 72.2 + doesn't work FIXED
     if ((result || "").includes('.')) {
@@ -253,21 +238,17 @@ class App extends React.Component {
     return result;
   };
   }
-
   getLastChar = (from) => {
     return from.slice(-1);
   }
-
   calculate = () => {
     const { result, operate, originalLastNum } = this.state;
     let finalResult = 0;
     var tempResult = result;
-
     // Special case with expression ending with operatore, after CE use
     if ("-+*/".includes(this.getLastChar(result))) {
       tempResult = result.slice(0,-1);
     }
-
     // Handling double equal
     // If I only have sign + digit(s) + dot + digit(s)
     const regex = /-{0,1}[0123456789]*(\.[0123456789]*){0,1}/g;
@@ -304,7 +285,6 @@ class App extends React.Component {
       // no level -> no ( inside ()) -> (2+5)*(5+6) -> order
       // level(nested) -> ( inside () -> 2(*(2+5))*5 -> 3*((2*5)/5)
       //  Rule: First you calculate the () withtout ( or ) inside
-
       var tempResultString = tempResult;
       //We need to detect the non nested parenthesis
       //Open ( and no other ( before the next close
@@ -319,7 +299,6 @@ class App extends React.Component {
           //We calculate the value ex: 7
           try {
             let tempResult = evaluate(expression);
-
             //We need to replace the expression by the calculation
             tempResultString = tempResultString.replace(expression, tempResult);
           } catch(error) {
@@ -329,14 +308,12 @@ class App extends React.Component {
         parenthesisToCalculate = tempResultString.match(reg) || [];
       }
       //In tempResultString we have the last expression withtout any ()
-
       try {
         finalResult = evaluate(tempResultString);
       } catch(error) {
         //throw error
       }
     }
-
     this.setState({
       done: true,
       result: (finalResult || "") + "",
@@ -359,8 +336,6 @@ class App extends React.Component {
   };
 
   render() {
-    // console.log(this.state);
-
     return (
       <div className="container">
         <h1>Pocket Js Calculator</h1>

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from "react";
 import "./App.css";
 import ResultComponent from "./Components/ResultComponent";
 import KeyPadComponent from "./Components/KeyPadComponent";
-import { evaluate } from "mathjs";
+import { evaluate, map } from "mathjs";
 
 class App extends React.Component {
   state = {
@@ -10,10 +10,16 @@ class App extends React.Component {
     counter: 0,
     done: false,
     operate: undefined,
-    originalLastNum: "",
+    originalLastNum: "", //lastResult === ['7*8', '(7*8)*8', '((7*8)*8)*8']
+    lastFormula: '',
   };
 
   onClick = (button) => {
+    console.log('onClick', this.state.result)
+
+    // const [result, lastFormula] = this.nextResult(button, this.state.result, this.state.lastFormula)
+    // this.setState({result, lastFormula})
+
     if (button.type === "key" || button.key === "(" || button.key === ")") {
       if (this.state.done) {
         this.setState({
@@ -57,6 +63,7 @@ class App extends React.Component {
         button.key !== "AC" &&
         button.key !== ")"
       ) {
+        console.log('entering this if loop', 'result:', this.state.result, 'operate', this.state.operate)
         this.setState({
           operate: button.key,
           //result: this.state.result + button.key,
@@ -92,16 +99,16 @@ class App extends React.Component {
   };
 
   changeKeys = (result, button) => {
+
     if ("(".includes(button)) {
       if (result.length > 1) {
-
         if ("0123456789".includes(result[result.length - 1])) {
           //remove the previous number and return the last number
           return result + button.replace("(", "*(");
         }
       }
     }
-    if (result === "") {
+    if (result === "") { //result === '2+', button === '.'
       if ("+-(0123456789".includes(button)) {
         return button;
       }
@@ -109,7 +116,7 @@ class App extends React.Component {
         return "0.";
       }
     }
-    if ("0123456789".includes(result[result.length - 1])) {
+    if (result && result.length >= 1 && "0123456789".includes(result[result.length - 1])) {
       const numberOfOpenP = (result.match(/\(/g) || []).length;
       const numberOfCloseP = (result.match(/\)/g) || []).length;
       if (
@@ -128,7 +135,7 @@ class App extends React.Component {
     // - sign
     // - ., but we need to add a zero before
     //ex: 59 - (
-    if (result[result.length - 1] === "(") {
+    if (result && result.length >= 1 && result[result.length - 1] === "(") {
       if ("+-(0123456789".includes(button)) {
         return result + button;
       }
@@ -138,7 +145,7 @@ class App extends React.Component {
     }
     //🪲BUG -> (7 +  isn't working, attempting fix with this if conditional
     if (
-      result[result.length - 1] === "(" &&
+      result && result.length >= 2 && result[result.length - 1] === "(" &&
       "/*+-".includes(button) &&
       result[result.length - 2].includes("0123456789(")
     ) {
@@ -147,7 +154,7 @@ class App extends React.Component {
     // After a ), you can only have
     // - operator
     // - ), only if there are more ( than )
-    if (result[result.length - 1] === ")") {
+    if (result && result.length >= 1 && result[result.length - 1] === ")") {
       const numberOfOpenP = (result.match(/\(/g) || []).length;
       const numberOfCloseP = (result.match(/\)/g) || []).length;
       if ("/*-+".includes(button)) {
@@ -170,7 +177,7 @@ class App extends React.Component {
     // - sign
     // - (
     // - ., but we need to add a zero before
-    if ("0123456789)".includes(result[result.length - 2])) {
+    if (result && result.length >= 2 && "0123456789)".includes(result[result.length - 2])) {
       //checking "digit, ) -> operator"
       if ("/*+-".includes(result[result.length - 1])) {
         if ("+-(0123456789".includes(button)) {
@@ -185,7 +192,7 @@ class App extends React.Component {
     // - digit
     // - (
     // - ., but we need to add a zero before
-    if ("/*+-(".includes(result[result.length - 2])) {
+    if (result && result.length >= 2 && "/*+-(".includes(result[result.length - 2])) {
       if ("-+".includes(result[result.length - 1])) {
         if ("0123456789(".includes(button)) {
           return result + button;
@@ -199,7 +206,7 @@ class App extends React.Component {
     // - digit
     // - (
     // - ., but we need to add a zero before
-    if (result[result.length - 2].includes("/*+-(")) {
+    if (result && result.length >= 2 && result[result.length - 2].includes("/*+-(")) {
       if (result[result.length - 1].includes("-+")) {
         if ("0123456789(".includes(button)) {
           return result + button;
@@ -209,13 +216,13 @@ class App extends React.Component {
         }
       }
     }
-    if ((result[result.length - 1] || "").includes(".")) {
+    if (result && result.length >= 1 && (result[result.length - 1] || "").includes(".")) {
       if ("0123456789".includes(button)) {
         return result + button;
       }
     }
     //🪲 72.2 + doesn't work FIXED
-    if (result.includes(".")) {
+    if (result && result.includes(".")) {
     //ATTN -> added rule below myself outside of our tutoring
 
        //🪲 72.2 + doesn't work FIXED

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -32,18 +32,6 @@ test("result displays correct number and operation when used together", () => {
   expect(getByTestId("result")).toHaveTextContent("9/");
 });
 
-//'CE button deletes previous number or command'
-// test('CE button displays when clicked', () => {
-//   const { getByTestId } = render(<App />);
-//   const children = 'CE'
-
-//   fireEvent.click(getByTestId("CE"))
-
-//   expect(getByTestId('result')).toHaveTextContent('/')
-
-//   userEvent.click(screen.getByRole('button', {name: /CE/i }))
-//   expect(screen.queryByText(children)).toBeInTheDocument();
-// })
 
 //Testing events
 it("state is updated when a button is clicked", () => {
@@ -199,7 +187,7 @@ describe("check the operation of 3 or more numbers", () => {
     expect(getByTestId("result")).toHaveTextContent("2.3")
   });
 
-  test("1.1 + 1.2 must equal 1.3", () => {
+  test("Multiple operations including parens", () => {
     const { getByTestId } = render(<App />);
 
     fireEvent.click(getByTestId(8));
@@ -221,8 +209,26 @@ describe("check the operation of 3 or more numbers", () => {
   });
 });
 
+// describe('clicking equals runs the operation again every time', () => {
+//   const { getByTestId } = render(<App />);
 
-describe('error message displaying at correct times', () => {
+//   fireEvent.click(getByTestId(1));
+//   fireEvent.click(getByTestId("."));
+//   fireEvent.click(getByTestId(1));
+//   fireEvent.click(getByTestId("+"));
+//   fireEvent.click(getByTestId(1));
+//   fireEvent.click(getByTestId("."));
+//   fireEvent.click(getByTestId(2));
+//   fireEvent.click(getByTestId("="));
+//   fireEvent.click(getByTestId("="));
+
+//   expect(getByTestId("result").toHaveTextContent(""))
+
+
+// })
+
+
+describe('removes characters appropriately', () => {
   test("multiplying 3 by 7 then adding 8 and hitting CE must remove 8", () => {
     const { getByTestId } = render(<App />);
 
@@ -235,8 +241,39 @@ describe('error message displaying at correct times', () => {
 
     expect(getByTestId("result")).toHaveTextContent("3*7+")
   });
+
+  test("double negative at the beginning of an expression defaults to one negative sign", () => {
+    const { getByTestId } = render(<App />);
+
+    fireEvent.click(getByTestId("-"));
+    fireEvent.click(getByTestId("-"));
+
+    expect(getByTestId("result")).toHaveTextContent("-")
+  })
+
+  test("using an addition followed by a multiplication operator defaults to a multiplication operator", () => {
+    const { getByTestId } = render(<App />);
+
+    fireEvent.click(getByTestId(7));
+    fireEvent.click(getByTestId("+"));
+    fireEvent.click(getByTestId("*"));
+
+    expect(getByTestId("result")).toHaveTextContent("7*")
+  })
 })
 
+// test("starting a new calculation after '=' has been pressed", () => {
+//   const { getByTestId } = render(<App />);
+
+//   fireEvent.click(getByTestId(3));
+//   fireEvent.click(getByTestId("*"));
+//   fireEvent.click(getByTestId(7));
+//   fireEvent.click(getByTestId("="));
+//   fireEvent.click(getByTestId(8));
+//   fireEvent.click(getByTestId(3));
+
+//   expect(getByTestId("result")).toHaveTextContent("83")
+// }) 
 
 
 // test('equal button is called one time', () => {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -128,7 +128,7 @@ describe("check operations of AC and CE", () => {
   });
 });
 
-describe("check the operation of 3 numbers", () => {
+describe("check the operation of 3 or more numbers", () => {
   test("multiplying 3 by 7 by 5 must result in 105", () => {
     const { getByTestId } = render(<App />);
 
@@ -197,6 +197,27 @@ describe("check the operation of 3 numbers", () => {
     fireEvent.click(getByTestId("="));
 
     expect(getByTestId("result")).toHaveTextContent("2.3")
+  });
+
+  test("1.1 + 1.2 must equal 1.3", () => {
+    const { getByTestId } = render(<App />);
+
+    fireEvent.click(getByTestId(8));
+    fireEvent.click(getByTestId("."));
+    fireEvent.click(getByTestId(7));
+    fireEvent.click(getByTestId("*"));
+    fireEvent.click(getByTestId(2));
+    fireEvent.click(getByTestId("+"));
+    fireEvent.click(getByTestId(6));
+    fireEvent.click(getByTestId("-"));
+    fireEvent.click(getByTestId("("));
+    fireEvent.click(getByTestId(7));
+    fireEvent.click(getByTestId("-"));
+    fireEvent.click(getByTestId(2));
+    fireEvent.click(getByTestId(")"));
+    fireEvent.click(getByTestId("="));
+
+    expect(getByTestId("result")).toHaveTextContent("18.4")
   });
 });
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -227,7 +227,7 @@ describe('removes characters appropriately', () => {
     fireEvent.click(getByTestId("CE"));
     fireEvent.click(getByTestId("="));
 
-    expect(getByTestId("result")).toHaveTextContent("3*7+")
+    expect(getByTestId("result")).toHaveTextContent("21")
   });
 
   test("double negative at the beginning of an expression defaults to one negative sign", () => {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,7 @@ import { render, userEvent, fireEvent, screen } from "@testing-library/react";
 import { evaluate } from "mathjs";
 import App from "./App";
 import ResultComponent from "./Components/ResultComponent";
-import { evaluate } from "mathjs";
+
 
 //snapshot
 it("matches snapshot", () => {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -20,7 +20,7 @@ test("division button displays when clicked", () => {
   const { getByTestId } = render(<App />);
 
   fireEvent.click(getByTestId("/"));
-  expect(getByTestId("result")).toHaveTextContent("/");
+  expect(getByTestId("result")).toHaveTextContent("");
 });
 
 test("result displays correct number and operation when used together", () => {
@@ -183,11 +183,26 @@ describe("check the operation of 3 numbers", () => {
 
     expect(getByTestId("result")).toHaveTextContent("11")
   });
+
+  test("1.1 + 1.2 must equal 1.3", () => {
+    const { getByTestId } = render(<App />);
+
+    fireEvent.click(getByTestId(1));
+    fireEvent.click(getByTestId("."));
+    fireEvent.click(getByTestId(1));
+    fireEvent.click(getByTestId("+"));
+    fireEvent.click(getByTestId(1));
+    fireEvent.click(getByTestId("."));
+    fireEvent.click(getByTestId(2));
+    fireEvent.click(getByTestId("="));
+
+    expect(getByTestId("result")).toHaveTextContent("2.3")
+  });
 });
 
 
 describe('error message displaying at correct times', () => {
-  test("multiplying 3 by 7 then adding 8 and hitting CE must equal error", () => {
+  test("multiplying 3 by 7 then adding 8 and hitting CE must remove 8", () => {
     const { getByTestId } = render(<App />);
 
     fireEvent.click(getByTestId(3));
@@ -196,9 +211,8 @@ describe('error message displaying at correct times', () => {
     fireEvent.click(getByTestId("+"));
     fireEvent.click(getByTestId(8));
     fireEvent.click(getByTestId("CE"));
-    fireEvent.click(getByTestId("="));
 
-    expect(getByTestId("result")).toHaveTextContent("error")
+    expect(getByTestId("result")).toHaveTextContent("3*7+")
   });
 })
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -210,25 +210,6 @@ describe("check the operation of 3 or more numbers", () => {
   });
 });
 
-// describe('clicking equals runs the operation again every time', () => {
-//   const { getByTestId } = render(<App />);
-
-//   fireEvent.click(getByTestId(1));
-//   fireEvent.click(getByTestId("."));
-//   fireEvent.click(getByTestId(1));
-//   fireEvent.click(getByTestId("+"));
-//   fireEvent.click(getByTestId(1));
-//   fireEvent.click(getByTestId("."));
-//   fireEvent.click(getByTestId(2));
-//   fireEvent.click(getByTestId("="));
-//   fireEvent.click(getByTestId("="));
-
-//   expect(getByTestId("result").toHaveTextContent(""))
-
-
-// })
-
-
 describe('removes characters appropriately', () => {
   test("multiplying 3 by 7 then adding 8 and hitting CE must remove 8", () => {
     const { getByTestId } = render(<App />);
@@ -265,22 +246,3 @@ describe('removes characters appropriately', () => {
     expect(getByTestId("result")).toHaveTextContent("7*")
   })
 })
-
-
-
-//const calculate = require('./App')
-// test('displays correct result of multiplying 8 by 7', () => {
-//   const { getByTestId } = render(<App />);
-
-//   expect(calculate(`${x} ${operation} ${y}`)).toBe(56)
-// })
-
-// it('displays correct result of multiplying 8 by 7', () => {
-//   const { getByTestId } = render(<App />);
-
-//   fireEvent.click(getByTestId("8"), getByTestId("*"), getByTestId("7"), getByTestId("="))
-
-//   expect(getByTestId("result")).toHaveTextContent("56")
-// })
-
-//Testing keyboard events

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,7 @@
 import { render, fireEvent } from "@testing-library/react";
 import App from "./App";
 import ResultComponent from "./Components/ResultComponent";
+import { evaluate } from "mathjs";
 
 //snapshot
 it("matches snapshot", () => {
@@ -59,7 +60,7 @@ const y = 7;
 const operation = "*";
 
 test("displays correct result of multiplying 8 by 7", () => {
-  expect(eval(`${x} ${operation} ${y}`)).toBe(56);
+  expect(evaluate(`${x} ${operation} ${y}`)).toBe(56);
 });
 
 describe("check the operation of 2 numbers", () => {

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`matches snapshot 1`] = `
 <DocumentFragment>
-  <div>
+  <div
+    class="container"
+  >
     <h1>
       Pocket Js Calculator
     </h1>

--- a/src/rules.txt
+++ b/src/rules.txt
@@ -130,3 +130,27 @@ if ((result.length - 1).includes('.')) {
 //do the operation inside the parens first and then multiply that by the number outside
 //what its doing right now is it is doing the operation inside the parens,
 // but then just affixing the number outside the parens to the result
+
+
+//if there is an operator of * or / entered after a + or -
+//the operator should default to the * or /
+//so 7-* should default to 7* and 7+/ should default to 7/
+//if ("/".includes(result[result.length - 1]) && "-".includes(result[result.length - 2]) {
+  result.replace('-', '/')
+}
+//if ("/".includes(result[result.length - 1]) && "+".includes(result[result.length - 2]) {
+  result.replace('+', '/')
+}
+//if ("*".includes(result[result.length - 1]) && "+".includes(result[result.length - 2]) {
+  result.replace('+', '*')
+}
+//if ("*".includes(result[result.length - 1]) && "-".includes(result[result.length - 2]) {
+  result.replace('-', '*')
+}
+
+
+const groupsOfOperators = /(\+-)(\*\\)/g;
+const multiplyOrDivide = /\*\//g;
+const addOrSub = /\+-/g;
+const subAndDiv = /(-\/)/g
+

--- a/src/rules_lastnum.txt
+++ b/src/rules_lastnum.txt
@@ -1,0 +1,31 @@
+Rules for the last number
+
+- digits
+- (
+- )
+- .
+- sign - +
+- operator - + / * 
+
+lastNum: empty
+- digits : add it
+- sign: add it
+- . add it
+
+- (,),operator: replace next
+
+(2*(22*-986))
+last num: number : + - [digits]
+2
+22
+-986
+//
+const regex = /[-+]{0,1}[0-9]{1,}[.]{0,1}[0-9]*/g;
+{1,} -> this is to say: At lEast one digit
+//
+......
+save one or more char
+everytime there is new one-> save it or record it
+the new char may depends on the last char input
+986 record 986 + + in operate
+98-6 record 6 + - in operate

--- a/src/rules_lastnum.txt
+++ b/src/rules_lastnum.txt
@@ -1,5 +1,4 @@
 Rules for the last number
-
 - digits
 - (
 - )
@@ -11,7 +10,6 @@ lastNum: empty
 - digits : add it
 - sign: add it
 - . add it
-
 - (,),operator: replace next
 
 (2*(22*-986))
@@ -20,9 +18,7 @@ last num: number : + - [digits]
 22
 -986
 //
-
 const regex = /[-+/*]{0,}[0-9]{1,}[.]{0,1}[0-9]*/g;
-
 {1,} -> this is to say: At lEast one digit
 //
 ......


### PR DESCRIPTION
We replaced eval() as using eval presents certain safety concerns, for example:

> If you run eval() with a string that could be affected by a malicious party, you may end up running malicious code on the user's machine with the permissions of your webpage / extension. 
[source, mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!)

So instead I imported a JS math library and used its evaluate() function to parse our mathematical expressions and return the correct results.

Issue #5 